### PR TITLE
[+] remove php-http/guzzle7-adapter from composer.json #WTT-13113

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "php": "^7.2|^8.0",
     "monolog/monolog": "^2.7",
     "http-interop/http-factory-guzzle": "^1.2",
-    "php-http/guzzle7-adapter": "^1.0",
     "sentry/sentry": "^3.3"
   },
   "require-dev": {


### PR DESCRIPTION
Классы `Http\Adapter\Guzzle7\*` в пакете не используются. Поэтому необходимости в этой зависимости нет. Не у всех 7-й адаптер guzzle стоит. В некоторых может 6-й стоять.

Пакет `sentry/sentry` может работать с адаптерами 6-й и 7-й версии:
https://github.com/getsentry/sentry-php/blob/97b215e64f07c679067bd26d5df18537c33a9457/src/HttpClient/HttpClientFactory.php#L9